### PR TITLE
remove :timedout from the session hash (https://github.com/plataformatec...

### DIFF
--- a/lib/growlyflash.rb
+++ b/lib/growlyflash.rb
@@ -20,7 +20,7 @@ module Growlyflash
   module NoticeHelpers
     def growlyflash_static_notices
       return nil unless flash.any?
-      javascript_tag "window.flashes = #{raw(Hash[flash].to_json)};", defer: 'defer'
+      javascript_tag "window.flashes = #{raw(Hash[flash].except!(:timedout).to_json)};", defer: 'defer'
     end
   end
   


### PR DESCRIPTION
I use devise in a project and just activated the timeout functionality. 
Since devise renders a :timedout => true into the flash Hash for some reason, this true value is rendered into the frontend. My hack just removes this key from the :timedout Hash.

There ist certainly a better solution for this, but it works well for my project and it might for others too :-)

the devise issue: https://github.com/plataformatec/devise/issues/1777
