### PR TITLE
deleting window.flashes after shown once to prevent duplicates appearing when using turbolinks

### DIFF
--- a/vendor/assets/javascripts/growlyflash/growlyflash.js.coffee
+++ b/vendor/assets/javascripts/growlyflash/growlyflash.js.coffee
@@ -11,7 +11,9 @@ class Growlyflash
     
   constructor: (@context) ->
     @flash_log = []
-    @growl window.flashes if window.flashes?
+    if window.flashes?
+      @growl window.flashes
+      delete window.flashes
     # we have to bind both of ajax-complete events
     # sometimes one of them takes messages and they are skipping
     # but in mostly, they produce duplicates :(  


### PR DESCRIPTION
Hi, this fixes an issue I was having with this plugin + turbolinks. Essentially since the page isn't reloaded, window.flashes remains set and the flash was displaying on all subsequent pages. Deleting the window.flashes after the first call fixed it for me. Thought you may want to include it in case others are experiencing this issue.
