### PR TITLE
Make title customizable again

### DIFF
--- a/app/assets/javascripts/growlyflash/alert.coffee
+++ b/app/assets/javascripts/growlyflash/alert.coffee
@@ -44,7 +44,7 @@ class Growlyflash
 
       html = ""
       html += h.dismiss() if dismiss
-      html += h.title(@opts.type) if title? and @opts.type?
+      html += h.title(@opts.type) if title and @opts.type?
       html += @flash.msg
 
       @el = ($ '<div>', html: html, class: @class_list().join(' '), role: "alert")


### PR DESCRIPTION
A really small change, but that `?` made the title to be always displayed no matter the value of the `title` property.

I also tested it on version `0.8.4.1` (before it was `title` instead of `title?`), and it worked as expected.

I'm not an expert on CoffeeScript so any suggestion is welcome!