### PR TITLE
Fix title option being ignored

### DIFF
--- a/app/assets/javascripts/growlyflash/alert.coffee
+++ b/app/assets/javascripts/growlyflash/alert.coffee
@@ -44,7 +44,7 @@ class Growlyflash
 
       html = ""
       html += h.dismiss() if dismiss
-      html += h.title(@opts.type) if title? and @opts.type?
+      html += h.title(@opts.type) if title and @opts.type?
       html += @flash.msg
 
       @el = ($ '<div>', html: html, class: @class_list().join(' '), role: "alert")


### PR DESCRIPTION
Setting `title = yes` or `title = no` is no longer respected due to regression from https://github.com/estum/growlyflash/commit/d6803925cd5f69e6e419e7a50f7e541a602e5a6c. This change fixes that.