### PR TITLE
Added method to one time pause of growly flash.

### DIFF
--- a/lib/growlyflash/controller_additions.rb
+++ b/lib/growlyflash/controller_additions.rb
@@ -23,9 +23,14 @@ module Growlyflash
 
     protected
 
+    def pause_growlyflash
+      @pause_growlyflash = true
+    end  
+
     # Dumps available messages to headers and discards them to prevent appear
     # it again after refreshing a page
     def flash_to_headers
+      return if @pause_growlyflash
       response.headers['X-Message'] = URI.escape(growlyhash(true).to_json)
       growlyhash.each_key { |k| flash.discard(k) }
     end


### PR DESCRIPTION
I have a controller action which returns a js code block via ajax. The code may do something or reload whole page. In this latter case it is better to display flash messages after page is reloaded. So there is need to pause `flash_to_headers` execution for a one action call. That why I added `pause_growlyflash`. 

PS. I prefer not to update the docs because I am not English native speaker.
