### PR TITLE
Content-Security-Policy: script-src: 'unsafe-inline' compliant

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,16 @@ To make notifications also available with non-XHR requests, insert the following
 <%= growlyflash_static_notices %>
 ```
 
+If you want your website to be compliant with Content-Security-Policy, and
+especially avoid `script-src: 'unsafe-inline'`, you can use another helper to
+render an html tag with data attributes instead of injecting javascript code
+into your page:
+
+```erb
+<%= growlyflash_tag %>
+```
+
+
 ## Customize
 
 If you want to change default options, you can override them somewhere in your coffee/js:

--- a/app/assets/javascripts/growlyflash/listener.coffee
+++ b/app/assets/javascripts/growlyflash/listener.coffee
@@ -31,16 +31,20 @@ class Listener
 
   constructor: (context) ->
     @stack ?= new Stack()
-    @process_static() if window.flashes?
+    @process_static(context)
     ($ context).on Growlyflash.Listener.EVENTS, (event, xhr) =>
       if xhr ?= event.data?.xhr
         source = process_from_header(xhr.getResponseHeader(Growlyflash.Listener.HEADER))
         @stack.push_only_fresh source
       return
 
-  process_static: ->
-    @stack.push alert for alert in process(window.flashes)
-    delete window.flashes
+  process_static: (context)->
+    if tag = context.getElementById('growlyflash-tag')
+      tag_flashes = JSON.parse(tag.getAttribute('data-flashes'))
+      @stack.push alert for alert in process(tag_flashes)
+    else if window.flashes?
+      @stack.push alert for alert in process(window.flashes)
+      delete window.flashes 
 
 @Growlyflash.Listener = Listener
 @Growlyflash.listen_on = (context) ->

--- a/lib/growlyflash/controller_additions.rb
+++ b/lib/growlyflash/controller_additions.rb
@@ -4,7 +4,7 @@ module Growlyflash
       base.module_eval do
         extend ClassMethods
         if respond_to?(:helper_method)
-          helper_method :growlyflash_static_notices, :growlyhash
+          helper_method :growlyflash_static_notices, :growlyhash, :growlyflash_tag
         end
       end
     end
@@ -36,6 +36,16 @@ module Growlyflash
       return if flash.empty?
       script = "#{js_var} = #{growlyhash.to_json.html_safe};".freeze
       view_context.javascript_tag(script, defer: 'defer')
+    end
+
+    # View helper which render a tag with flashes messages in data attribute.
+    def growlyflash_tag
+      return if flash.empty?
+      view_context.tag(
+        :div,
+        id: 'growlyflash-tag',
+        'data-flashes': growlyhash.to_json.html_safe
+      )
     end
 
     # Hash with available growl flash messages which contains a string object.


### PR DESCRIPTION
Don't inject javascript code into html page to be compliant with Content-Security-Policy `script-src: 'unsafe-inline'` header. 

https://developer.mozilla.org/fr/docs/Web/HTTP/Headers/Content-Security-Policy/script-src